### PR TITLE
fix(deploy): support Vercel preview domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 DJANGO_SECRET_KEY=replace-with-a-long-random-secret-key
 DJANGO_DEBUG=true
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+# For Vercel preview deployments, use https://*.vercel.app.
+CSRF_TRUSTED_ORIGINS=
 
 # Optional locally; required for PostgreSQL deployments such as Supabase.
 # Copy the URI from Supabase Dashboard > Connect. Do not commit the real value.

--- a/BookNexus/settings.py
+++ b/BookNexus/settings.py
@@ -50,11 +50,18 @@ SECRET_KEY = os.environ.get(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
-ALLOWED_HOSTS = (
-    [host for host in os.environ.get("DJANGO_ALLOWED_HOSTS", "").split(",") if host]
-    if not DEBUG
-    else []
-)
+
+def get_environment_list(variable_name: str) -> list[str]:
+    """Return comma-separated environment values without surrounding whitespace."""
+    return [
+        value.strip()
+        for value in os.environ.get(variable_name, "").split(",")
+        if value.strip()
+    ]
+
+
+ALLOWED_HOSTS = get_environment_list("DJANGO_ALLOWED_HOSTS") if not DEBUG else []
+CSRF_TRUSTED_ORIGINS = get_environment_list("CSRF_TRUSTED_ORIGINS")
 
 
 # Application definition

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Configure the values required by your environment:
 | `DJANGO_SECRET_KEY` | Django cryptographic key | Yes |
 | `DJANGO_DEBUG` | Enables development mode | Yes |
 | `DJANGO_ALLOWED_HOSTS` | Hosts allowed when debug is disabled | Production only |
+| `CSRF_TRUSTED_ORIGINS` | HTTPS origins trusted for POST requests | Production only |
 | `DATABASE_URL` | PostgreSQL connection URI; uses local SQLite when omitted | Production only |
 | `LLM_PROVIDER` | `groq` or `openai` | For recommendations |
 | `GROQ_API_KEY` / `OPENAI_API_KEY` | Credentials for the selected LLM provider | For recommendations |


### PR DESCRIPTION
Allow Vercel deployment hosts and configure trusted CSRF origins through environment variables for secure preview and production requests.