### PR TITLE
fix(deploy): collect static assets for Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Django
 DJANGO_SECRET_KEY=replace-with-a-long-random-secret-key
+# Keep this enabled only for local development. Vercel must use false.
 DJANGO_DEBUG=true
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 # Django accepts both DJANGO_ALLOWED_HOSTS and ALLOWED_HOSTS.

--- a/BookNexus/settings.py
+++ b/BookNexus/settings.py
@@ -48,7 +48,7 @@ SECRET_KEY = os.environ.get(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
+DEBUG = os.environ.get("DJANGO_DEBUG", "false").strip().lower() == "true"
 
 
 def get_environment_list(*variable_names: str) -> list[str]:
@@ -184,6 +184,7 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Configure the values required by your environment:
 | Variable | Purpose | Required locally |
 | --- | --- | --- |
 | `DJANGO_SECRET_KEY` | Django cryptographic key | Yes |
-| `DJANGO_DEBUG` | Enables development mode | Yes |
+| `DJANGO_DEBUG` | Enables development mode; must be `false` in deployments | Yes, locally |
 | `DJANGO_ALLOWED_HOSTS` | Hosts allowed when debug is disabled | Production only |
 | `ALLOWED_HOSTS` | Alternative name accepted for deployment hosts | Production only |
 | `CSRF_TRUSTED_ORIGINS` | HTTPS origins trusted for POST requests | Production only |


### PR DESCRIPTION
Configure Django static output so Vercel can publish styles and scripts through its CDN.